### PR TITLE
boy scout: add debian family support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,12 @@ galaxy_info:
         - '8'
         - '9'
 
+    - name: Debian
+      version:
+        - buster
+        - bullseye
+        - bookworm
+
   galaxy_tags:
     - hosts
 

--- a/templates/hosts_debian.j2
+++ b/templates/hosts_debian.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+
+# -----------------------------------------------------------------------------
+# self
+# -----------------------------------------------------------------------------
+
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+{% if system_hosts_manage_self %}
+{% if system_domain is defined %}
+127.0.1.1       {{ system_hostname }}.{{ system_domain }} {{ system_hostname }}
+{% else %}
+127.0.1.1       {{ system_hostname }}
+{% endif %}
+{% endif %}
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+{% if system_hosts_sections | length %}
+{% for section in system_hosts_sections %}
+
+# -----------------------------------------------------------------------------
+# {{ section.name }}
+# -----------------------------------------------------------------------------
+
+{% for host in section.entries %}
+{% if host.aliases is defined %}
+{{ "%-16s" | format(host.address) }}{{ host.name }} {{ host.aliases | join(' ') }}
+{% else %}
+{{ "%-16s" | format(host.address) }}{{ host.name }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Template build from a Debian 12 (bookworm) `/etc/hosts` to harmonize diffs.